### PR TITLE
Deep sort JSON data to ease source-control management

### DIFF
--- a/bin/getApp.py
+++ b/bin/getApp.py
@@ -406,7 +406,17 @@ try:
         processTypedElementFunc(elements, type)
 
 
+    # Recurse through the entire JSON tree and sort all key/values
+    def sortedDeep(d):
+        def makeTuple(v): return (*v,) if isinstance(v,(list,dict)) else (v,)
+        if isinstance(d,list):
+            return sorted( map(sortedDeep,d) ,key=makeTuple )
+        if isinstance(d,dict):
+            return { k: sortedDeep(d[k]) for k in sorted(d)}
+        return d
+
     def jsonToFile(jData, type,filename, altSubDir=None):
+        jData = sortedDeep(jData)
         # replace spaces in filename to make the files sed friendly
         filename2 = filename.replace(' ', '_')
         if altSubDir is None:


### PR DESCRIPTION
The current JSON-sorting logic in `jsonToFile()` does not sort the sub-key/value pairs of the JSON, only the top key/value pairs. This adds additional sorting to deep sort all of the values which makes git-type diffs easier to compare and store.

I can share privately some examples if needed to show the difference. An example is that we index Confluence wiki by space names, and we have thousands of space names in the indexer. When the export happens, the list of space names is random, which causes the `git diff` to appear as if many changes were made. This logic improves this to make the changes more clear.