### PR TITLE
Do not pop "blobs" unless they exist

### DIFF
--- a/bin/getApp.py
+++ b/bin/getApp.py
@@ -241,7 +241,10 @@ try:
                     exportParams = makeExportParamsFromJson(j)
                     ## in addition to processing all of the zip files from exportParam sets, we need to output
                     # APP and possibly features but don't grab blobs and collections.  Those need to come from full zips
-                    j['objects'].pop('blobs')
+                    if 'blobs' in j['objects']:
+                        j['objects'].pop('blobs')
+                    else:
+                        debug("blobs key does not exist")
                     j['objects'].pop('collections')
 
                     verbose(f"Extracting contents of downloaded APP {args.app}")

--- a/bin/getApp.py
+++ b/bin/getApp.py
@@ -241,11 +241,15 @@ try:
                     exportParams = makeExportParamsFromJson(j)
                     ## in addition to processing all of the zip files from exportParam sets, we need to output
                     # APP and possibly features but don't grab blobs and collections.  Those need to come from full zips
+                    # Might depend on 5.x release whether the object exists - remove them if present
                     if 'blobs' in j['objects']:
                         j['objects'].pop('blobs')
                     else:
                         debug("blobs key does not exist")
-                    j['objects'].pop('collections')
+                    if 'collections' in j['objects']:
+                        j['objects'].pop('collections')
+                    else:
+                        debug("collections key does not exist")
 
                     verbose(f"Extracting contents of downloaded APP {args.app}")
                     extractAppFromZip(objects=j,validateAppName=True)


### PR DESCRIPTION
I am running Fusion 5.5.1 and there is no object named "blobs" returned, so this errors out. The PR checks if blobs exists and removes it only if it exists.